### PR TITLE
T/4: The position of the floating toolbar should be updated after the editable has grown.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@ckeditor/ckeditor5-dev-lint": "^2.0.2",
     "@ckeditor/ckeditor5-basic-styles": "^0.8.0",
     "@ckeditor/ckeditor5-paragraph": "^0.7.0",
+    "@ckeditor/ckeditor5-presets": "^0.2.1",
     "gulp": "^3.9.0",
     "guppy-pre-commit": "^0.4.0"
   },

--- a/src/inlineeditorui.js
+++ b/src/inlineeditorui.js
@@ -45,12 +45,6 @@ export default class InlineEditorUI {
 		this.focusTracker = new FocusTracker();
 
 		// Set–up the view#panel.
-		const { nw, sw, ne, se } = InlineEditorUI.defaultPositions;
-		const panelOptions = {
-			target: view.editableElement,
-			positions: [ nw, sw, ne, se ]
-		};
-
 		view.panel.bind( 'isVisible' ).to( this.focusTracker, 'isFocused' );
 
 		// https://github.com/ckeditor/ckeditor5-editor-inline/issues/4
@@ -58,7 +52,10 @@ export default class InlineEditorUI {
 			// Don't pin if the panel is not already visible. It prevents the panel
 			// showing up when there's no focus in the UI.
 			if ( view.panel.isVisible ) {
-				view.panel.pin( panelOptions );
+				view.panel.pin( {
+					target: view.editableElement,
+					positions: view.panelPositions
+				} );
 			}
 		} );
 
@@ -105,68 +102,3 @@ export default class InlineEditorUI {
 		return this.view.destroy();
 	}
 }
-
-/**
- * A default set of positioning functions used by the toolbar to float around
- * {@link module:editor-inline/inlineeditoruiview~InlineEditorUIView#editableElement}.
- *
- * The available positioning functions are as follows:
- *
- * * South east:
- *
- *		+------------------+
- *		| #editableElement |
- *		+------------------+
- *		           [ Panel ]
- *
- * * South west:
- *
- *		+------------------+
- *		| #editableElement |
- *		+------------------+
- *		[ Panel ]
- *
- * * North east:
- *
- *		           [ Panel ]
- *		+------------------+
- *		| #editableElement |
- *		+------------------+
- *
- *
- * * North west:
- *
- *		[ Panel ]
- *		+------------------+
- *		| #editableElement |
- *		+------------------+
- *
- * Positioning functions must be compatible with {@link module:utils/dom/position~Position}.
- *
- * @member {Object} module:editor-inline/inlineeditorui~InlineEditorUI.defaultPositions
- */
-InlineEditorUI.defaultPositions = {
-	nw: ( targetRect, panelRect ) => ( {
-		top: targetRect.top - panelRect.height,
-		left: targetRect.left,
-		name: 'toolbar_nw'
-	} ),
-
-	sw: ( targetRect ) => ( {
-		top: targetRect.bottom,
-		left: targetRect.left,
-		name: 'toolbar_sw'
-	} ),
-
-	ne: ( targetRect, panelRect ) => ( {
-		top: targetRect.top - panelRect.height,
-		left: targetRect.left + targetRect.width - panelRect.width,
-		name: 'toolbar_ne'
-	} ),
-
-	se: ( targetRect, panelRect ) => ( {
-		top: targetRect.bottom,
-		left: targetRect.left + targetRect.width - panelRect.width,
-		name: 'toolbar_se'
-	} )
-};

--- a/src/inlineeditorui.js
+++ b/src/inlineeditorui.js
@@ -55,7 +55,11 @@ export default class InlineEditorUI {
 
 		// https://github.com/ckeditor/ckeditor5-editor-inline/issues/4
 		view.listenTo( editor.editing.view, 'render', () => {
-			view.panel.pin( panelOptions );
+			// Don't pin if the panel is not already visible. It prevents the panel
+			// showing up when there's no focus in the UI.
+			if ( view.panel.isVisible ) {
+				view.panel.pin( panelOptions );
+			}
 		} );
 
 		// Setup the editable.

--- a/src/inlineeditorui.js
+++ b/src/inlineeditorui.js
@@ -44,13 +44,18 @@ export default class InlineEditorUI {
 		 */
 		this.focusTracker = new FocusTracker();
 
-		const { nw, sw, ne, se } = InlineEditorUI.defaultPositions;
-
 		// Set–up the view#panel.
-		view.panel.bind( 'isVisible' ).to( this.focusTracker, 'isFocused' );
-		view.panel.pin( {
+		const { nw, sw, ne, se } = InlineEditorUI.defaultPositions;
+		const panelOptions = {
 			target: view.editableElement,
 			positions: [ nw, sw, ne, se ]
+		};
+
+		view.panel.bind( 'isVisible' ).to( this.focusTracker, 'isFocused' );
+
+		// https://github.com/ckeditor/ckeditor5-editor-inline/issues/4
+		view.listenTo( editor.editing.view, 'render', () => {
+			view.panel.pin( panelOptions );
 		} );
 
 		// Setup the editable.

--- a/src/inlineeditorui.js
+++ b/src/inlineeditorui.js
@@ -44,9 +44,14 @@ export default class InlineEditorUI {
 		 */
 		this.focusTracker = new FocusTracker();
 
+		const { nw, sw, ne, se } = InlineEditorUI.defaultPositions;
+
 		// Set–up the view#panel.
-		view.panel.bind( 'isActive' ).to( this.focusTracker, 'isFocused' );
-		view.panel.targetElement = view.editableElement;
+		view.panel.bind( 'isVisible' ).to( this.focusTracker, 'isFocused' );
+		view.panel.pin( {
+			target: view.editableElement,
+			positions: [ nw, sw, ne, se ]
+		} );
 
 		// Setup the editable.
 		const editingRoot = editor.editing.createRoot( view.editableElement );
@@ -91,3 +96,68 @@ export default class InlineEditorUI {
 		return this.view.destroy();
 	}
 }
+
+/**
+ * A default set of positioning functions used by the toolbar to float around
+ * {@link module:editor-inline/inlineeditoruiview~InlineEditorUIView#editableElement}.
+ *
+ * The available positioning functions are as follows:
+ *
+ * * South east:
+ *
+ *		+------------------+
+ *		| #editableElement |
+ *		+------------------+
+ *		           [ Panel ]
+ *
+ * * South west:
+ *
+ *		+------------------+
+ *		| #editableElement |
+ *		+------------------+
+ *		[ Panel ]
+ *
+ * * North east:
+ *
+ *		           [ Panel ]
+ *		+------------------+
+ *		| #editableElement |
+ *		+------------------+
+ *
+ *
+ * * North west:
+ *
+ *		[ Panel ]
+ *		+------------------+
+ *		| #editableElement |
+ *		+------------------+
+ *
+ * Positioning functions must be compatible with {@link module:utils/dom/position~Position}.
+ *
+ * @member {Object} module:editor-inline/inlineeditorui~InlineEditorUI.defaultPositions
+ */
+InlineEditorUI.defaultPositions = {
+	nw: ( targetRect, panelRect ) => ( {
+		top: targetRect.top - panelRect.height,
+		left: targetRect.left,
+		name: 'toolbar_nw'
+	} ),
+
+	sw: ( targetRect ) => ( {
+		top: targetRect.bottom,
+		left: targetRect.left,
+		name: 'toolbar_sw'
+	} ),
+
+	ne: ( targetRect, panelRect ) => ( {
+		top: targetRect.top - panelRect.height,
+		left: targetRect.left + targetRect.width - panelRect.width,
+		name: 'toolbar_ne'
+	} ),
+
+	se: ( targetRect, panelRect ) => ( {
+		top: targetRect.bottom,
+		left: targetRect.left + targetRect.width - panelRect.width,
+		name: 'toolbar_se'
+	} )
+};

--- a/src/inlineeditoruiview.js
+++ b/src/inlineeditoruiview.js
@@ -77,4 +77,73 @@ export default class InlineEditorUIView extends EditorUIView {
 	get editableElement() {
 		return this.editable.element;
 	}
+
+	/**
+	 * A set of positioning functions used by the {@link #panel} to float around
+	 * {@link #editableElement}.
+	 *
+	 * The positioning functions are as follows:
+	 *
+	 * * South east:
+	 *
+	 *		+------------------+
+	 *		| #editableElement |
+	 *		+------------------+
+	 *		           [ Panel ]
+	 *
+	 * * South west:
+	 *
+	 *		+------------------+
+	 *		| #editableElement |
+	 *		+------------------+
+	 *		[ Panel ]
+	 *
+	 * * North east:
+	 *
+	 *		           [ Panel ]
+	 *		+------------------+
+	 *		| #editableElement |
+	 *		+------------------+
+	 *
+	 *
+	 * * North west:
+	 *
+	 *		[ Panel ]
+	 *		+------------------+
+	 *		| #editableElement |
+	 *		+------------------+
+	 *
+	 * @type {module:utils/dom/position~Options#positions}
+	 */
+	get panelPositions() {
+		return panelPositions;
+	}
 }
+
+// A set of positioning functions used by the
+// {@link module:editor-inline/inlineeditoruiview~InlineEditableUIView#panel}.
+//
+// @private
+// @type {module:utils/dom/position~Options#positions}
+const panelPositions = [
+	( editableRect, panelRect ) => ( {
+		top: editableRect.top - panelRect.height,
+		left: editableRect.left,
+		name: 'toolbar_nw'
+	} ),
+	( editableRect ) => ( {
+		top: editableRect.bottom,
+		left: editableRect.left,
+		name: 'toolbar_sw'
+	} ),
+	( editableRect, panelRect ) => ( {
+		top: editableRect.top - panelRect.height,
+		left: editableRect.left + editableRect.width - panelRect.width,
+		name: 'toolbar_ne'
+	} ),
+	( editableRect, panelRect ) => ( {
+		top: editableRect.bottom,
+		left: editableRect.left + editableRect.width - panelRect.width,
+		name: 'toolbar_se'
+	} )
+];

--- a/src/inlineeditoruiview.js
+++ b/src/inlineeditoruiview.js
@@ -9,7 +9,7 @@
 
 import EditorUIView from '@ckeditor/ckeditor5-ui/src/editorui/editoruiview';
 import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
-import FloatingPanelView from '@ckeditor/ckeditor5-ui/src/panel/floating/floatingpanelview';
+import BalloonPanelView from '@ckeditor/ckeditor5-ui/src/panel/balloon/balloonpanelview';
 import ToolbarView from '@ckeditor/ckeditor5-ui/src/toolbar/toolbarview';
 import Template from '@ckeditor/ckeditor5-ui/src/template';
 
@@ -36,12 +36,14 @@ export default class InlineEditorUIView extends EditorUIView {
 		this.toolbar = new ToolbarView( locale );
 
 		/**
-		 * A floating panel view instance.
+		 * A balloon panel view instance.
 		 *
 		 * @readonly
-		 * @member {module:ui/panel/floating/floatingpanelview~FloatingPanelView}
+		 * @member {module:ui/panel/balloon/balloonpanelview~BalloonPanelView}
 		 */
-		this.panel = new FloatingPanelView( locale );
+		this.panel = new BalloonPanelView( locale );
+
+		this.panel.withArrow = false;
 
 		Template.extend( this.panel.template, {
 			attributes: {

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -69,8 +69,14 @@ describe( 'InlineEditorUI', () => {
 			it( 'pin() is called on editor.editable.view#render', () => {
 				const spy = sinon.spy( view.panel, 'pin' );
 
-				editor.editing.view.fire( 'render' );
+				view.panel.hide();
 
+				editor.editing.view.fire( 'render' );
+				sinon.assert.notCalled( spy );
+
+				view.panel.show();
+
+				editor.editing.view.fire( 'render' );
 				sinon.assert.calledOnce( spy );
 			} );
 		} );

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -57,16 +57,12 @@ describe( 'InlineEditorUI', () => {
 		} );
 
 		describe( 'panel', () => {
-			it( 'binds view.panel#isActive to editor.ui#focusTracker', () => {
+			it( 'binds view.panel#isVisible to editor.ui#focusTracker', () => {
 				ui.focusTracker.isFocused = false;
-				expect( view.panel.isActive ).to.be.false;
+				expect( view.panel.isVisible ).to.be.false;
 
 				ui.focusTracker.isFocused = true;
-				expect( view.panel.isActive ).to.be.true;
-			} );
-
-			it( 'sets view.panel#targetElement', () => {
-				expect( view.panel.targetElement ).to.equal( view.editableElement );
+				expect( view.panel.isVisible ).to.be.true;
 			} );
 		} );
 

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -78,6 +78,10 @@ describe( 'InlineEditorUI', () => {
 
 				editor.editing.view.fire( 'render' );
 				sinon.assert.calledOnce( spy );
+				sinon.assert.calledWithExactly( spy, {
+					target: view.editableElement,
+					positions: sinon.match.array
+				} );
 			} );
 		} );
 

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -64,6 +64,15 @@ describe( 'InlineEditorUI', () => {
 				ui.focusTracker.isFocused = true;
 				expect( view.panel.isVisible ).to.be.true;
 			} );
+
+			// https://github.com/ckeditor/ckeditor5-editor-inline/issues/4
+			it( 'pin() is called on editor.editable.view#render', () => {
+				const spy = sinon.spy( view.panel, 'pin' );
+
+				editor.editing.view.fire( 'render' );
+
+				sinon.assert.calledOnce( spy );
+			} );
 		} );
 
 		describe( 'editable', () => {

--- a/tests/inlineeditoruiview.js
+++ b/tests/inlineeditoruiview.js
@@ -71,7 +71,7 @@ describe( 'InlineEditorUIView', () => {
 		} );
 	} );
 
-	describe( 'init', () => {
+	describe( 'init()', () => {
 		it( 'appends #toolbar to panel#content', () => {
 			expect( view.panel.content ).to.have.length( 0 );
 
@@ -90,6 +90,54 @@ describe( 'InlineEditorUIView', () => {
 					expect( view.editableElement.getAttribute( 'contentEditable' ) ).to.equal( 'true' );
 				} )
 				.then( () => view.destroy() );
+		} );
+	} );
+
+	describe( 'panelPositions', () => {
+		it( 'returns the right positions in the right order', () => {
+			const positions = view.panelPositions;
+			const editableRect = {
+				top: 100,
+				bottom: 200,
+				left: 100,
+				right: 100,
+				width: 100,
+				height: 100
+			};
+			const panelRect = {
+				top: 0,
+				bottom: 0,
+				left: 0,
+				right: 0,
+				width: 50,
+				height: 50
+			};
+
+			expect( positions ).to.have.length( 4 );
+
+			expect( positions[ 0 ]( editableRect, panelRect ) ).to.deep.equal( {
+				name: 'toolbar_nw',
+				left: 100,
+				top: 50
+			} );
+
+			expect( positions[ 1 ]( editableRect, panelRect ) ).to.deep.equal( {
+				name: 'toolbar_sw',
+				left: 100,
+				top: 200
+			} );
+
+			expect( positions[ 2 ]( editableRect, panelRect ) ).to.deep.equal( {
+				name: 'toolbar_ne',
+				left: 150,
+				top: 50
+			} );
+
+			expect( positions[ 3 ]( editableRect, panelRect ) ).to.deep.equal( {
+				name: 'toolbar_se',
+				left: 150,
+				top: 200
+			} );
 		} );
 	} );
 } );

--- a/tests/inlineeditoruiview.js
+++ b/tests/inlineeditoruiview.js
@@ -5,7 +5,7 @@
 
 import InlineEditorUIView from '../src/inlineeditoruiview';
 import ToolbarView from '@ckeditor/ckeditor5-ui/src/toolbar/toolbarview';
-import FloatingPanelView from '@ckeditor/ckeditor5-ui/src/panel/floating/floatingpanelview';
+import BalloonPanelView from '@ckeditor/ckeditor5-ui/src/panel/balloon/balloonpanelview';
 import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
 import Locale from '@ckeditor/ckeditor5-utils/src/locale';
 
@@ -30,7 +30,7 @@ describe( 'InlineEditorUIView', () => {
 
 		describe( '#panel', () => {
 			it( 'is created', () => {
-				expect( view.panel ).to.be.instanceof( FloatingPanelView );
+				expect( view.panel ).to.be.instanceof( BalloonPanelView );
 			} );
 
 			it( 'is given a locale object', () => {
@@ -43,6 +43,10 @@ describe( 'InlineEditorUIView', () => {
 
 			it( 'is put into the #body collection', () => {
 				expect( view.body.get( 0 ) ).to.equal( view.panel );
+			} );
+
+			it( 'gets view.panel#withArrow set', () => {
+				expect( view.panel.withArrow ).to.be.false;
 			} );
 		} );
 

--- a/tests/manual/tickets/4/1.html
+++ b/tests/manual/tickets/4/1.html
@@ -1,0 +1,10 @@
+<style>
+	body {
+		height: 10000px;
+	}
+</style>
+
+<div id="editor">
+    <p>Content of the editor.</p>
+</div>
+

--- a/tests/manual/tickets/4/1.js
+++ b/tests/manual/tickets/4/1.js
@@ -1,0 +1,20 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console:false, document, window */
+
+import InlineEditor from '../../../../src/inline';
+import ArticlePreset from '@ckeditor/ckeditor5-presets/src/article';
+
+InlineEditor.create( document.querySelector( '#editor' ), {
+	plugins: [ ArticlePreset ],
+	toolbar: [ 'headings', 'bold', 'italic', 'link', 'unlink', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ]
+} )
+.then( editor => {
+	window.editor = editor;
+} )
+.catch( err => {
+	console.error( err.stack );
+} );

--- a/tests/manual/tickets/4/1.md
+++ b/tests/manual/tickets/4/1.md
@@ -1,0 +1,7 @@
+### Issue [#4](https://github.com/ckeditor/ckeditor5-editor-inline/issues/4) manual test
+
+1. Focus the editor,
+2. Scroll the web page until the toolbar is visible below editable,
+3. Type a couple of new lines in the editor,
+
+Expected: The toolbar should stick to the bottom edge of editable as the editable has grown up.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The position of the floating toolbar should be updated after the editable has grown. Closes #4.

---

### Additional information

Requires https://github.com/ckeditor/ckeditor5-ui/pull/197.
