### PR TITLE
t/11: The toolbar should not collapse when the window is narrow

### DIFF
--- a/src/inlineeditoruiview.js
+++ b/src/inlineeditoruiview.js
@@ -59,7 +59,12 @@ export default class InlineEditorUIView extends EditorUIView {
 
 		Template.extend( this.toolbar.template, {
 			attributes: {
-				class: 'ck-editor-toolbar'
+				class: [
+					'ck-editor-toolbar',
+
+					// https://github.com/ckeditor/ckeditor5-editor-inline/issues/11
+					'ck-toolbar_floating'
+				]
 			}
 		} );
 

--- a/tests/inlineeditoruiview.js
+++ b/tests/inlineeditoruiview.js
@@ -26,6 +26,11 @@ describe( 'InlineEditorUIView', () => {
 			it( 'is given a locale object', () => {
 				expect( view.toolbar.locale ).to.equal( locale );
 			} );
+
+			it( 'is given the right CSS classes', () => {
+				expect( view.toolbar.element.classList.contains( 'ck-editor-toolbar' ) ).to.be.true;
+				expect( view.toolbar.element.classList.contains( 'ck-toolbar_floating' ) ).to.be.true;
+			} );
 		} );
 
 		describe( '#panel', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The toolbar should not collapse when the window is narrow. Closes #11.

---

### Additional information

Requires https://github.com/ckeditor/ckeditor5-theme-lark/pull/94.
