### PR TITLE
RootEditableElement is created together with the editor structure.

### DIFF
--- a/src/inlineeditorui.js
+++ b/src/inlineeditorui.js
@@ -52,6 +52,10 @@ export default class InlineEditorUI {
 		 * @private
 		 */
 		this._toolbarConfig = normalizeToolbarConfig( editor.config.get( 'toolbar' ) );
+
+		// RootEditableElement should be created together with the editor structure.
+		// See https://github.com/ckeditor/ckeditor5/issues/647.
+		editor.editing.createRoot( view.editableElement );
 	}
 
 	/**
@@ -83,7 +87,7 @@ export default class InlineEditorUI {
 		} );
 
 		// Setup the editable.
-		const editingRoot = editor.editing.createRoot( view.editableElement );
+		const editingRoot = editor.editing.view.getRoot();
 		view.editable.bind( 'isReadOnly' ).to( editingRoot );
 
 		// Bind to focusTracker instead of editor.editing.view because otherwise

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -7,6 +7,7 @@
 
 import ComponentFactory from '@ckeditor/ckeditor5-ui/src/componentfactory';
 import View from '@ckeditor/ckeditor5-ui/src/view';
+import RootEditableElement from '@ckeditor/ckeditor5-engine/src/view/rooteditableelement';
 
 import InlineEditorUI from '../src/inlineeditorui';
 import InlineEditorUIView from '../src/inlineeditoruiview';
@@ -55,6 +56,10 @@ describe( 'InlineEditorUI', () => {
 
 		it( 'creates #focusTracker', () => {
 			expect( ui.focusTracker ).to.be.instanceOf( FocusTracker );
+		} );
+
+		it( 'creates root editable element', () => {
+			expect( editor.editing.view.getRoot() ).to.be.instanceOf( RootEditableElement );
 		} );
 
 		describe( 'panel', () => {

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -61,6 +61,12 @@ describe( 'InlineEditorUI', () => {
 		it( 'creates root editable element', () => {
 			expect( editor.editing.view.getRoot() ).to.be.instanceOf( RootEditableElement );
 		} );
+	} );
+
+	describe( 'init()', () => {
+		it( 'renders the #view', () => {
+			expect( view.isRendered ).to.be.true;
+		} );
 
 		describe( 'panel', () => {
 			it( 'binds view.panel#isVisible to editor.ui#focusTracker', () => {
@@ -151,12 +157,6 @@ describe( 'InlineEditorUI', () => {
 					{ isReadOnly: true }
 				);
 			} );
-		} );
-	} );
-
-	describe( 'init()', () => {
-		it( 'renders the #view', () => {
-			expect( view.isRendered ).to.be.true;
 		} );
 
 		describe( 'view.toolbar#items', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: `RootEditableElement` is created together with the editor structure. Closes https://github.com/ckeditor/ckeditor5/issues/647.