### PR TITLE
Removed `.ck-editor-toolbar` class in ToolbarView

### DIFF
--- a/src/inlineeditoruiview.js
+++ b/src/inlineeditoruiview.js
@@ -52,8 +52,6 @@ export default class InlineEditorUIView extends EditorUIView {
 		this.toolbar.extendTemplate( {
 			attributes: {
 				class: [
-					'ck-editor-toolbar',
-
 					// https://github.com/ckeditor/ckeditor5-editor-inline/issues/11
 					'ck-toolbar_floating'
 				]

--- a/tests/inlineeditoruiview.js
+++ b/tests/inlineeditoruiview.js
@@ -33,7 +33,6 @@ describe( 'InlineEditorUIView', () => {
 			} );
 
 			it( 'is given the right CSS classes', () => {
-				expect( view.toolbar.element.classList.contains( 'ck-editor-toolbar' ) ).to.be.true;
 				expect( view.toolbar.element.classList.contains( 'ck-toolbar_floating' ) ).to.be.true;
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

BREAKING CHANGE:  Removed `.ck-editor-toolbar` class in `ToolbarView`.

---

### Additional information

* A piece of https://github.com/ckeditor/ckeditor5-theme-lark/issues/135
