### PR TITLE
Allow to pass initial data to the editor constructor

### DIFF
--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -55,8 +55,10 @@ export default class InlineEditor extends Editor {
 	 * {@link module:editor-inline/inlineeditor~InlineEditor.create `InlineEditor.create()`} method instead.
 	 *
 	 * @protected
-	 * @param {HTMLElement} elementOrData The DOM element that will be the source for the created editor
-	 * (on which the editor will be initialized).
+	 * @param {HTMLElement|String} elementOrData The DOM element that will be the source for the created editor
+	 * (on which the editor will be initialized) or initial data for the editor. If data is provided, `editor.element`
+	 * will be created automatically and need to be added manually to the DOM. For more information see
+	 * {@link module:editor-inline/inlineeditor~InlineEditor.create `InlineEditor.create()`}.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 */
 	constructor( elementOrData, config ) {
@@ -129,8 +131,32 @@ export default class InlineEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * @param {HTMLElement} elementOrData The DOM element that will be the source for the created editor
-	 * (on which the editor will be initialized).
+	 * Creating instance when using initial data instead of DOM element:
+	 *
+	 *		import InlineEditor from '@ckeditor/ckeditor5-editor-inline/src/inlineeditor';
+	 *		import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+	 *		import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+	 *		import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+	 *		import ...
+	 *
+	 *		InlineEditor
+	 *			.create( '<p>Hello world!</p>, {
+	 *				plugins: [ Essentials, Bold, Italic, ... ],
+	 *				toolbar: [ 'bold', 'italic', ... ]
+	 *			} )
+	 *			.then( editor => {
+	 *				console.log( 'Editor was initialized', editor );
+	 *
+	 *				// Initial data was provided so `editor.element` needs to be added manually to the DOM.
+	 *				document.body.appendChild( editor.element );
+	 *			} )
+	 *			.catch( err => {
+	 *				console.error( err.stack );
+	 *			} );
+	 *
+	 * @param {HTMLElement|String} elementOrData The DOM element that will be the source for the created editor
+	 * (on which the editor will be initialized) or initial data for the editor. If data is provided, `editor.element`
+	 * will be created automatically and need to be added manually to the DOM.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 * @returns {Promise} A promise resolved once the editor is ready.
 	 * The promise returns the created {@link module:editor-inline/inlineeditor~InlineEditor} instance.

--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -18,7 +18,6 @@ import setDataInElement from '@ckeditor/ckeditor5-utils/src/dom/setdatainelement
 import getDataFromElement from '@ckeditor/ckeditor5-utils/src/dom/getdatafromelement';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import isElement from '@ckeditor/ckeditor5-utils/src/lib/lodash/isElement';
-import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
 /**
  * The {@glink builds/guides/overview#inline-editor inline editor} implementation.
@@ -80,8 +79,6 @@ export default class InlineEditor extends Editor {
 
 		if ( isElement( sourceElementOrData ) ) {
 			this.sourceElement = sourceElementOrData;
-		} else {
-			this.sourceElement = global.document.createElement( 'div' );
 		}
 
 		this.ui = new InlineEditorUI( this, new InlineEditorUIView( this.locale, this.sourceElement ) );
@@ -90,9 +87,7 @@ export default class InlineEditor extends Editor {
 	}
 
 	/**
-	 * An HTML element that represents the whole editor. See the {@link module:core/editor/editorwithui~EditorWithUI} interface.
-	 *
-	 * @returns {HTMLElement|null}
+	 * @inheritDoc
 	 */
 	get element() {
 		return this.ui.view.editable.element;

--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -17,6 +17,7 @@ import InlineEditorUIView from './inlineeditoruiview';
 import setDataInElement from '@ckeditor/ckeditor5-utils/src/dom/setdatainelement';
 import getDataFromElement from '@ckeditor/ckeditor5-utils/src/dom/getdatafromelement';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
+import isElement from '@ckeditor/ckeditor5-utils/src/lib/lodash/isElement';
 
 /**
  * The {@glink builds/guides/overview#inline-editor inline editor} implementation.
@@ -53,20 +54,24 @@ export default class InlineEditor extends Editor {
 	 * {@link module:editor-inline/inlineeditor~InlineEditor.create `InlineEditor.create()`} method instead.
 	 *
 	 * @protected
-	 * @param {HTMLElement} element The DOM element that will be the source for the created editor
+	 * @param {HTMLElement} elementOrData The DOM element that will be the source for the created editor
 	 * (on which the editor will be initialized).
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 */
-	constructor( element, config ) {
+	constructor( elementOrData, config ) {
 		super( config );
-
-		this.element = element;
 
 		this.data.processor = new HtmlDataProcessor();
 
 		this.model.document.createRoot();
 
-		this.ui = new InlineEditorUI( this, new InlineEditorUIView( this.locale, element ) );
+		if ( isElement( elementOrData ) ) {
+			this.element = elementOrData;
+		} else {
+			this.element = document.createElement( 'div' );
+		}
+
+		this.ui = new InlineEditorUI( this, new InlineEditorUIView( this.locale, this.element ) );
 
 		attachToForm( this );
 	}
@@ -123,15 +128,15 @@ export default class InlineEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * @param {HTMLElement} element The DOM element that will be the source for the created editor
+	 * @param {HTMLElement} elementOrData The DOM element that will be the source for the created editor
 	 * (on which the editor will be initialized).
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 * @returns {Promise} A promise resolved once the editor is ready.
 	 * The promise returns the created {@link module:editor-inline/inlineeditor~InlineEditor} instance.
 	 */
-	static create( element, config ) {
+	static create( elementOrData, config ) {
 		return new Promise( resolve => {
-			const editor = new this( element, config );
+			const editor = new this( elementOrData, config );
 
 			resolve(
 				editor.initPlugins()
@@ -139,7 +144,7 @@ export default class InlineEditor extends Editor {
 						editor.ui.init();
 						editor.fire( 'uiReady' );
 					} )
-					.then( () => editor.data.init( getDataFromElement( element ) ) )
+					.then( () => editor.data.init( isElement( elementOrData ) ? getDataFromElement( elementOrData ) : elementOrData ) )
 					.then( () => {
 						editor.fire( 'dataReady' );
 						editor.fire( 'ready' );

--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -101,7 +101,7 @@ export default class InlineEditor extends Editor {
 	}
 
 	/**
-	 * Creates a inline editor instance.
+	 * Creates an inline editor instance.
 	 *
 	 * Creating instance when using {@glink builds/index CKEditor build}:
 	 *

--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -140,7 +140,7 @@ export default class InlineEditor extends Editor {
 	 *		import ...
 	 *
 	 *		InlineEditor
-	 *			.create( '<p>Hello world!</p>, {
+	 *			.create( '<p>Hello world!</p>', {
 	 *				plugins: [ Essentials, Bold, Italic, ... ],
 	 *				toolbar: [ 'bold', 'italic', ... ]
 	 *			} )

--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -97,7 +97,11 @@ export default class InlineEditor extends Editor {
 		this.ui.destroy();
 
 		return super.destroy()
-			.then( () => setDataInElement( this.sourceElement, data ) );
+			.then( () => {
+				if ( this.sourceElement ) {
+					setDataInElement( this.sourceElement, data );
+				}
+			} );
 	}
 
 	/**

--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -7,8 +7,6 @@
  * @module editor-inline/inlineeditor
  */
 
-/* global document */
-
 import Editor from '@ckeditor/ckeditor5-core/src/editor/editor';
 import DataApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/dataapimixin';
 import ElementApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/elementapimixin';
@@ -20,6 +18,7 @@ import setDataInElement from '@ckeditor/ckeditor5-utils/src/dom/setdatainelement
 import getDataFromElement from '@ckeditor/ckeditor5-utils/src/dom/getdatafromelement';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import isElement from '@ckeditor/ckeditor5-utils/src/lib/lodash/isElement';
+import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
 /**
  * The {@glink builds/guides/overview#inline-editor inline editor} implementation.
@@ -70,7 +69,7 @@ export default class InlineEditor extends Editor {
 		if ( isElement( elementOrData ) ) {
 			this.element = elementOrData;
 		} else {
-			this.element = document.createElement( 'div' );
+			this.element = global.document.createElement( 'div' );
 		}
 
 		this.ui = new InlineEditorUI( this, new InlineEditorUIView( this.locale, this.element ) );

--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -187,9 +187,11 @@ export default class InlineEditor extends Editor {
 						editor.fire( 'uiReady' );
 					} )
 					.then( () => {
-						const data = isElement( sourceElementOrData ) ? getDataFromElement( sourceElementOrData ) : sourceElementOrData;
+						const initialData = isElement( sourceElementOrData ) ?
+							getDataFromElement( sourceElementOrData ) :
+							sourceElementOrData;
 
-						return editor.data.init( data );
+						return editor.data.init( initialData );
 					} )
 					.then( () => {
 						editor.fire( 'dataReady' );

--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -7,6 +7,8 @@
  * @module editor-inline/inlineeditor
  */
 
+/* global document */
+
 import Editor from '@ckeditor/ckeditor5-core/src/editor/editor';
 import DataApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/dataapimixin';
 import ElementApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/elementapimixin';

--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -55,23 +55,12 @@ export default class InlineEditor extends Editor {
 	 *
 	 * @protected
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
-	 * (on which the editor will be initialized) or initial data for the editor. If data is provided, `editor.element`
-	 * will be created automatically and need to be added manually to the DOM. For more information see
+	 * (on which the editor will be initialized) or initial data for the editor. For more information see
 	 * {@link module:editor-inline/inlineeditor~InlineEditor.create `InlineEditor.create()`}.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 */
 	constructor( sourceElementOrData, config ) {
 		super( config );
-
-		/**
-		 * The element on which the editor has been initialized.
-		 * If editor was initialized with data instead of HTMLElement this property will keep a reference to newly
-		 * created element that need to be added manually to the DOM. For more information see
-		 * {@link module:editor-inline/inlineeditor~InlineEditor.create `InlineEditor.create()`}.
-		 *
-		 * @readonly
-		 * @member {HTMLElement} #element
-		 */
 
 		this.data.processor = new HtmlDataProcessor();
 
@@ -145,7 +134,7 @@ export default class InlineEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * Creating instance when using initial data instead of DOM element:
+	 * Creating instance when using initial data instead of a DOM element:
 	 *
 	 *		import InlineEditor from '@ckeditor/ckeditor5-editor-inline/src/inlineeditor';
 	 *		import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
@@ -154,10 +143,7 @@ export default class InlineEditor extends Editor {
 	 *		import ...
 	 *
 	 *		InlineEditor
-	 *			.create( '<p>Hello world!</p>', {
-	 *				plugins: [ Essentials, Bold, Italic, ... ],
-	 *				toolbar: [ 'bold', 'italic', ... ]
-	 *			} )
+	 *			.create( '<p>Hello world!</p>' )
 	 *			.then( editor => {
 	 *				console.log( 'Editor was initialized', editor );
 	 *
@@ -169,9 +155,14 @@ export default class InlineEditor extends Editor {
 	 *			} );
 	 *
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
-	 * (on which the editor will be initialized) or initial data for the editor. If data is provided, `editor.element`
-	 * will be created automatically and need to be added manually to the DOM. The element is initialized as a `div`
-	 * element crated in current document's context.
+	 * (on which the editor will be initialized) or initial data for the editor.
+	 *
+	 * If a source element is passed, then its contents will be automatically
+	 * {@link module:editor-classic/inlineeditor~InlineEditor#setData loaded} to the editor on startup and the element
+	 * itself will be used as the editor's editable element.
+	 *
+	 * If a data is provided, then `editor.element` will be created automatically and needs to be added
+	 * manually to the DOM.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 * @returns {Promise} A promise resolved once the editor is ready.
 	 * The promise returns the created {@link module:editor-inline/inlineeditor~InlineEditor} instance.

--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -64,6 +64,16 @@ export default class InlineEditor extends Editor {
 	constructor( elementOrData, config ) {
 		super( config );
 
+		/**
+		 * The element on which the editor has been initialized.
+		 * If editor was initialized with data instead of HTMLElement this property will keep a reference to newly
+		 * created element that need to be added manually to the DOM. For more information see
+		 * {@link module:editor-inline/inlineeditor~InlineEditor.create `InlineEditor.create()`}.
+		 *
+		 * @readonly
+		 * @member {HTMLElement} #element
+		 */
+
 		this.data.processor = new HtmlDataProcessor();
 
 		this.model.document.createRoot();
@@ -156,7 +166,8 @@ export default class InlineEditor extends Editor {
 	 *
 	 * @param {HTMLElement|String} elementOrData The DOM element that will be the source for the created editor
 	 * (on which the editor will be initialized) or initial data for the editor. If data is provided, `editor.element`
-	 * will be created automatically and need to be added manually to the DOM.
+	 * will be created automatically and need to be added manually to the DOM. The element is initialized as a `div`
+	 * element crated in current document's context.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 * @returns {Promise} A promise resolved once the editor is ready.
 	 * The promise returns the created {@link module:editor-inline/inlineeditor~InlineEditor} instance.

--- a/tests/inlineeditor.js
+++ b/tests/inlineeditor.js
@@ -54,11 +54,11 @@ describe( 'InlineEditor', () => {
 		} );
 
 		it( 'has a Data Interface', () => {
-			testUtils.isMixed( InlineEditor, DataApiMixin );
+			expect( testUtils.isMixed( InlineEditor, DataApiMixin ) ).to.be.true;
 		} );
 
 		it( 'has a Element Interface', () => {
-			testUtils.isMixed( InlineEditor, ElementApiMixin );
+			expect( testUtils.isMixed( InlineEditor, ElementApiMixin ) ).to.be.true;
 		} );
 
 		it( 'creates main root element', () => {
@@ -104,12 +104,19 @@ describe( 'InlineEditor', () => {
 			} );
 		} );
 
+		it( 'editor.sourceElement should contain created div element', () => {
+			return InlineEditor.create( '<p>Hello world!</p>', {
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.sourceElement ).to.be.instanceOf( HTMLElement );
+				expect( editor.sourceElement.tagName ).to.equal( 'DIV' );
+			} );
+		} );
+
 		it( 'editor.element should contain created div element', () => {
 			return InlineEditor.create( '<p>Hello world!</p>', {
 				plugins: [ Paragraph ]
 			} ).then( editor => {
-				expect( editor.element ).to.be.instanceOf( HTMLElement );
-				expect( editor.element.tagName ).to.equal( 'DIV' );
 				expect( editor.editing.view.getDomRoot() ).to.equal( editor.element );
 			} );
 		} );

--- a/tests/inlineeditor.js
+++ b/tests/inlineeditor.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals document, Event, HTMLElement */
+/* globals document, Event */
 
 import InlineEditorUI from '../src/inlineeditorui';
 import InlineEditorUIView from '../src/inlineeditoruiview';
@@ -104,16 +104,15 @@ describe( 'InlineEditor', () => {
 			} );
 		} );
 
-		it( 'editor.sourceElement should contain created div element', () => {
+		it( 'should have undefined the #sourceElement if editor was initialized with data', () => {
 			return InlineEditor.create( '<p>Hello world!</p>', {
 				plugins: [ Paragraph ]
 			} ).then( editor => {
-				expect( editor.sourceElement ).to.be.instanceOf( HTMLElement );
-				expect( editor.sourceElement.tagName ).to.equal( 'DIV' );
+				expect( editor.sourceElement ).to.be.undefined;
 			} );
 		} );
 
-		it( 'editor.element should contain created div element', () => {
+		it( 'editor.element should contain the whole UI element', () => {
 			return InlineEditor.create( '<p>Hello world!</p>', {
 				plugins: [ Paragraph ]
 			} ).then( editor => {

--- a/tests/inlineeditor.js
+++ b/tests/inlineeditor.js
@@ -288,5 +288,13 @@ describe( 'InlineEditor', () => {
 						.to.equal( '<p>a</p><heading>b</heading>' );
 				} );
 		} );
+
+		it( 'should not throw an error if editor was initialized with the data', () => {
+			return InlineEditor
+				.create( '<p>Foo.</p>', {
+					plugins: [ Paragraph, Bold ]
+				} )
+				.then( newEditor => newEditor.destroy() );
+		} );
 	} );
 } );

--- a/tests/inlineeditor.js
+++ b/tests/inlineeditor.js
@@ -112,7 +112,7 @@ describe( 'InlineEditor', () => {
 			} );
 		} );
 
-		it( 'editor.element should contain the whole UI element', () => {
+		it( 'editor.element should contain the whole editor (with UI) element', () => {
 			return InlineEditor.create( '<p>Hello world!</p>', {
 				plugins: [ Paragraph ]
 			} ).then( editor => {

--- a/tests/inlineeditor.js
+++ b/tests/inlineeditor.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals document, Event */
+/* globals document, Event, HTMLElement */
 
 import InlineEditorUI from '../src/inlineeditorui';
 import InlineEditorUIView from '../src/inlineeditoruiview';
@@ -93,6 +93,24 @@ describe( 'InlineEditor', () => {
 				return editor.destroy().then( () => {
 					form.remove();
 				} );
+			} );
+		} );
+
+		it( 'allows to pass data to the constructor', () => {
+			return InlineEditor.create( '<p>Hello world!</p>', {
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.getData() ).to.equal( '<p>Hello world!</p>' );
+			} );
+		} );
+
+		it( 'editor.element should contain created div element', () => {
+			return InlineEditor.create( '<p>Hello world!</p>', {
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.element ).to.be.instanceOf( HTMLElement );
+				expect( editor.element.tagName ).to.equal( 'DIV' );
+				expect( editor.editing.view.getDomRoot() ).to.equal( editor.element );
 			} );
 		} );
 	} );

--- a/tests/manual/inlineeditor-data.html
+++ b/tests/manual/inlineeditor-data.html
@@ -3,9 +3,16 @@
 	<button id="initEditor">Init editor</button>
 </p>
 
+<div class="container"></div>
+
 <style>
 	body {
 		width: 10000px;
 		height: 10000px;
+	}
+
+	.container {
+		padding: 20px;
+		width: 500px;
 	}
 </style>

--- a/tests/manual/inlineeditor-data.html
+++ b/tests/manual/inlineeditor-data.html
@@ -1,5 +1,5 @@
 <p>
-	<button id="destroyEditor">Destroy editor</button>
+	<button id="destroyEditors">Destroy editors</button>
 	<button id="initEditor">Init editor</button>
 </p>
 

--- a/tests/manual/inlineeditor-data.html
+++ b/tests/manual/inlineeditor-data.html
@@ -1,0 +1,18 @@
+<p>
+	<button id="destroyEditor">Destroy editor</button>
+	<button id="initEditor">Init editor</button>
+</p>
+
+<style>
+	body {
+		width: 10000px;
+		height: 10000px;
+	}
+
+	.custom-class {
+		margin-top: 100px;
+		margin-left: 100px;
+		margin-bottom: 100px;
+		width: 450px;
+	}
+</style>

--- a/tests/manual/inlineeditor-data.html
+++ b/tests/manual/inlineeditor-data.html
@@ -8,11 +8,4 @@
 		width: 10000px;
 		height: 10000px;
 	}
-
-	.custom-class {
-		margin-top: 100px;
-		margin-left: 100px;
-		margin-bottom: 100px;
-		width: 450px;
-	}
 </style>

--- a/tests/manual/inlineeditor-data.js
+++ b/tests/manual/inlineeditor-data.js
@@ -9,16 +9,17 @@ import InlineEditor from '../../src/inlineeditor';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 
 window.editors = [];
-
 const container = document.querySelector( '.container' );
+let counter = 1;
 
 function initEditor() {
 	InlineEditor
-		.create( '<h2>Editor 1</h2><p>This is an editor instance.</p>', {
+		.create( `<h2>Editor ${ counter }</h2><p>This is an editor instance.</p>`, {
 			plugins: [ ArticlePluginSet ],
 			toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ]
 		} )
 		.then( editor => {
+			counter += 1;
 			window.editors.push( editor );
 			container.appendChild( editor.element );
 		} )
@@ -27,14 +28,16 @@ function initEditor() {
 		} );
 }
 
-function destroyEditor() {
+function destroyEditors() {
 	window.editors.forEach( editor => {
 		editor.destroy()
 			.then( () => {
 				editor.element.remove();
 			} );
 	} );
+	window.editors = [];
+	counter = 1;
 }
 
 document.getElementById( 'initEditor' ).addEventListener( 'click', initEditor );
-document.getElementById( 'destroyEditor' ).addEventListener( 'click', destroyEditor );
+document.getElementById( 'destroyEditors' ).addEventListener( 'click', destroyEditors );

--- a/tests/manual/inlineeditor-data.js
+++ b/tests/manual/inlineeditor-data.js
@@ -1,0 +1,38 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console:false, document, window */
+
+import InlineEditor from '../../src/inlineeditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+
+window.editors = [];
+
+function initEditor() {
+	InlineEditor
+		.create( '<h2>Editor 1</h2><p>This is an editor instance.</p>', {
+			plugins: [ ArticlePluginSet ],
+			toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ]
+		} )
+		.then( editor => {
+			window.editors.push( editor );
+			document.body.appendChild( editor.element );
+		} )
+		.catch( err => {
+			console.error( err.stack );
+		} );
+}
+
+function destroyEditor() {
+	window.editors.forEach( editor => {
+		editor.destroy()
+			.then( () => {
+				editor.element.remove();
+			} );
+	} );
+}
+
+document.getElementById( 'initEditor' ).addEventListener( 'click', initEditor );
+document.getElementById( 'destroyEditor' ).addEventListener( 'click', destroyEditor );

--- a/tests/manual/inlineeditor-data.js
+++ b/tests/manual/inlineeditor-data.js
@@ -10,6 +10,8 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 
 window.editors = [];
 
+const container = document.querySelector( '.container' );
+
 function initEditor() {
 	InlineEditor
 		.create( '<h2>Editor 1</h2><p>This is an editor instance.</p>', {
@@ -18,7 +20,7 @@ function initEditor() {
 		} )
 		.then( editor => {
 			window.editors.push( editor );
-			document.body.appendChild( editor.element );
+			container.appendChild( editor.element );
 		} )
 		.catch( err => {
 			console.error( err.stack );

--- a/tests/manual/inlineeditor-data.md
+++ b/tests/manual/inlineeditor-data.md
@@ -1,3 +1,3 @@
 1. Click "Init editor".
-2. New editor instance should be appended to the document with initial data in it.
+2. New editor instance should be appended to the document with initial data in it. You can create more than one editor.
 3. After clicking "Destroy editor" all editors should be removed from the document.

--- a/tests/manual/inlineeditor-data.md
+++ b/tests/manual/inlineeditor-data.md
@@ -1,0 +1,20 @@
+1. Click "Init editors".
+2. Expected:
+  * Two inline editor should be created.
+  * Elements used as editables should remain visible.
+    * They should preserve `.custom-class` and `custom-attr="foo"`.
+  * There should be floating toolbars with "Bold", "Italic", "Undo", "Redo", "Link" and "Unlink" buttons.
+3. Scroll the webpage.
+4. Expected:
+  * Focused editor's toolbar should float around but always stick to editable.
+  * Focused editor's toolbar should stick to the bottom of the editable if there's not enough space above.
+5. Press <kbd>Alt+F10</kbd> when focusing the editor.
+6. Expected:
+  * Toolbar should gain focus. Editable should keep its styling.
+7. Click "Destroy editors".
+8. Expected:
+  * Editors should be destroyed.
+  * Element used as editables should remain visible.
+    * They should preserve `.custom-class` and `custom-attr="foo"`.
+  * Elements should contain its data (updated).
+  * `.ck-body` regions should be removed from `<body>`.

--- a/tests/manual/inlineeditor-data.md
+++ b/tests/manual/inlineeditor-data.md
@@ -1,20 +1,3 @@
-1. Click "Init editors".
-2. Expected:
-  * Two inline editor should be created.
-  * Elements used as editables should remain visible.
-    * They should preserve `.custom-class` and `custom-attr="foo"`.
-  * There should be floating toolbars with "Bold", "Italic", "Undo", "Redo", "Link" and "Unlink" buttons.
-3. Scroll the webpage.
-4. Expected:
-  * Focused editor's toolbar should float around but always stick to editable.
-  * Focused editor's toolbar should stick to the bottom of the editable if there's not enough space above.
-5. Press <kbd>Alt+F10</kbd> when focusing the editor.
-6. Expected:
-  * Toolbar should gain focus. Editable should keep its styling.
-7. Click "Destroy editors".
-8. Expected:
-  * Editors should be destroyed.
-  * Element used as editables should remain visible.
-    * They should preserve `.custom-class` and `custom-attr="foo"`.
-  * Elements should contain its data (updated).
-  * `.ck-body` regions should be removed from `<body>`.
+1. Click "Init editor".
+2. New editor instance should be appended to the document with initial data in it.
+3. After clicking "Destroy editor" all editors should be removed from the document.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Editor can be created with initial data passed to the constructor. Closes #37.

BREAKING CHANGE: `InlineEditor#element` is now available as `InlineEditor#sourceElement`. See ckeditor/ckeditor5-core#64.

Requires: https://github.com/ckeditor/ckeditor5-core/pull/129