### PR TITLE
Adjustments to new `data#ready` event

### DIFF
--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -180,10 +180,7 @@ export default class InlineEditor extends Editor {
 
 						return editor.data.init( initialData );
 					} )
-					.then( () => {
-						editor.fire( 'dataReady' );
-						editor.fire( 'ready' );
-					} )
+					.then( () => editor.fire( 'ready' ) )
 					.then( () => editor )
 			);
 		} );

--- a/tests/inlineeditor.js
+++ b/tests/inlineeditor.js
@@ -197,7 +197,6 @@ describe( 'InlineEditor', () => {
 
 			class EventWatcher extends Plugin {
 				init() {
-					this.editor.plugins.on( 'ready', spy );
 					this.editor.ui.on( 'ready', spy );
 					this.editor.data.on( 'ready', spy );
 					this.editor.on( 'ready', spy );
@@ -210,7 +209,7 @@ describe( 'InlineEditor', () => {
 				} )
 				.then( newEditor => {
 					expect( fired ).to.deep.equal( [
-						'ready-plugincollection', 'ready-inlineeditorui', 'ready-datacontroller', 'ready-inlineeditor' ] );
+						'ready-inlineeditorui', 'ready-datacontroller', 'ready-inlineeditor' ] );
 
 					editor = newEditor;
 				} );

--- a/tests/inlineeditor.js
+++ b/tests/inlineeditor.js
@@ -192,12 +192,12 @@ describe( 'InlineEditor', () => {
 			const fired = [];
 
 			function spy( evt ) {
-				fired.push( evt.name );
+				fired.push( `${ evt.name }-${ evt.source.constructor.name.toLowerCase() }` );
 			}
 
 			class EventWatcher extends Plugin {
 				init() {
-					this.editor.on( 'pluginsReady', spy );
+					this.editor.plugins.on( 'ready', spy );
 					this.editor.ui.on( 'ready', spy );
 					this.editor.on( 'dataReady', spy );
 					this.editor.on( 'ready', spy );
@@ -209,7 +209,8 @@ describe( 'InlineEditor', () => {
 					plugins: [ EventWatcher ]
 				} )
 				.then( newEditor => {
-					expect( fired ).to.deep.equal( [ 'pluginsReady', 'ready', 'dataReady', 'ready' ] );
+					expect( fired ).to.deep.equal( [
+						'ready-plugincollection', 'ready-inlineeditorui', 'dataReady-inlineeditor', 'ready-inlineeditor' ] );
 
 					editor = newEditor;
 				} );

--- a/tests/inlineeditor.js
+++ b/tests/inlineeditor.js
@@ -199,7 +199,7 @@ describe( 'InlineEditor', () => {
 				init() {
 					this.editor.plugins.on( 'ready', spy );
 					this.editor.ui.on( 'ready', spy );
-					this.editor.on( 'dataReady', spy );
+					this.editor.data.on( 'ready', spy );
 					this.editor.on( 'ready', spy );
 				}
 			}
@@ -210,29 +210,7 @@ describe( 'InlineEditor', () => {
 				} )
 				.then( newEditor => {
 					expect( fired ).to.deep.equal( [
-						'ready-plugincollection', 'ready-inlineeditorui', 'dataReady-inlineeditor', 'ready-inlineeditor' ] );
-
-					editor = newEditor;
-				} );
-		} );
-
-		it( 'fires dataReady once data is loaded', () => {
-			let data;
-
-			class EventWatcher extends Plugin {
-				init() {
-					this.editor.on( 'dataReady', () => {
-						data = this.editor.getData();
-					} );
-				}
-			}
-
-			return InlineEditor
-				.create( editorElement, {
-					plugins: [ EventWatcher, Paragraph, Bold ]
-				} )
-				.then( newEditor => {
-					expect( data ).to.equal( '<p><strong>foo</strong> bar</p>' );
+						'ready-plugincollection', 'ready-inlineeditorui', 'ready-datacontroller', 'ready-inlineeditor' ] );
 
 					editor = newEditor;
 				} );

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -257,7 +257,6 @@ class VirtualInlineTestEditor extends VirtualTestEditor {
 				editor.initPlugins()
 					.then( () => {
 						editor.ui.init();
-						editor.fire( 'dataReady' );
 						editor.fire( 'ready' );
 					} )
 					.then( () => editor )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Adjustments to new `data#ready` event.

BREAKING CHANGE: The `editor#dataReady` event was removed. The `editor.data#ready` event has been introduced and should be used instead.

---

### Additional information

See https://github.com/ckeditor/ckeditor5/issues/1477.
