### PR TITLE
Added documentation for editor-create-initial-data error

### DIFF
--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -179,9 +179,14 @@ export default class InlineEditor extends Editor {
 					} )
 					.then( () => {
 						if ( !isElement( sourceElementOrData ) && config.initialData ) {
+							/**
+							 * Configuration parameter `initialData` cannot be used together with initial data passed in `Editor#create()`.
+							 *
+							 * @error editor-create-initial-data
+							 */
 							throw new CKEditorError(
 								'editor-create-initial-data: ' +
-								'EditorConfig#initialData cannot be used together with initial data passed in Editor#create()'
+								'Configuration parameter initialData cannot be used together with initial data passed in Editor#create()'
 							);
 						}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Added documentation for editor-create-initial-data error. Closes https://github.com/ckeditor/ckeditor5/issues/1665.