### PR TITLE
i/5597: Set inline toolbar's max-width

### DIFF
--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -73,7 +73,9 @@ export default class InlineEditor extends Editor {
 			secureSourceElement( this );
 		}
 
-		const view = new InlineEditorUIView( this.locale, this.editing.view, this.sourceElement );
+		const shouldToolbarGroupWhenFull = !this.config.get( 'toolbar.shouldNotGroupWhenFull' );
+
+		const view = new InlineEditorUIView( this.locale, this.editing.view, this.sourceElement, { shouldToolbarGroupWhenFull } );
 		this.ui = new InlineEditorUI( this, view );
 
 		attachToForm( this );

--- a/src/inlineeditor.js
+++ b/src/inlineeditor.js
@@ -75,7 +75,9 @@ export default class InlineEditor extends Editor {
 
 		const shouldToolbarGroupWhenFull = !this.config.get( 'toolbar.shouldNotGroupWhenFull' );
 
-		const view = new InlineEditorUIView( this.locale, this.editing.view, this.sourceElement, { shouldToolbarGroupWhenFull } );
+		const view = new InlineEditorUIView( this.locale, this.editing.view, this.sourceElement, {
+			shouldToolbarGroupWhenFull
+		} );
 		this.ui = new InlineEditorUI( this, view );
 
 		attachToForm( this );

--- a/src/inlineeditorui.js
+++ b/src/inlineeditorui.js
@@ -11,6 +11,7 @@ import EditorUI from '@ckeditor/ckeditor5-core/src/editor/editorui';
 import enableToolbarKeyboardFocus from '@ckeditor/ckeditor5-ui/src/toolbar/enabletoolbarkeyboardfocus';
 import normalizeToolbarConfig from '@ckeditor/ckeditor5-ui/src/toolbar/normalizetoolbarconfig';
 import { enablePlaceholder } from '@ckeditor/ckeditor5-engine/src/view/placeholder';
+import Rect from '@ckeditor/ckeditor5-utils/src/dom/rect';
 
 /**
  * The inline editor UI class.
@@ -139,6 +140,12 @@ export default class InlineEditorUI extends EditorUI {
 					target: editableElement,
 					positions: view.panelPositions
 				} );
+
+				// Set toolbar's max-width only once.
+				if ( !toolbar.element.style.maxWidth ) {
+					const editableRect = new Rect( editableElement );
+					toolbar.element.style.maxWidth = `${ editableRect.width }px`;
+				}
 			}
 		} );
 

--- a/src/inlineeditorui.js
+++ b/src/inlineeditorui.js
@@ -156,7 +156,7 @@ export default class InlineEditorUI extends EditorUI {
 			toolbar
 		} );
 
-		// Set toolbar's max-width on the initialization and update it on the editable resize,
+		// Set the toolbar's max-width on the initialization and update it on the editable resize,
 		// if 'shouldToolbarGroupWhenFull' in config is set to 'true'.
 		if ( !this._toolbarConfig.shouldNotGroupWhenFull ) {
 			const widthObserver = getResizeObserver( () => {

--- a/src/inlineeditorui.js
+++ b/src/inlineeditorui.js
@@ -133,6 +133,10 @@ export default class InlineEditorUI extends EditorUI {
 
 		// https://github.com/ckeditor/ckeditor5-editor-inline/issues/4
 		view.listenTo( editor.ui, 'update', () => {
+			if ( !editableElement.ownerDocument.body.contains( editableElement ) ) {
+				return;
+			}
+
 			// Don't pin if the panel is not already visible. It prevents the panel
 			// showing up when there's no focus in the UI.
 			if ( view.panel.isVisible ) {
@@ -142,9 +146,8 @@ export default class InlineEditorUI extends EditorUI {
 				} );
 
 				// Set toolbar's max-width only once.
-				if ( !toolbar.element.style.maxWidth ) {
-					const editableRect = new Rect( editableElement );
-					toolbar.element.style.maxWidth = `${ editableRect.width }px`;
+				if ( toolbar.element.style.maxWidth === '' ) {
+					this._setToolbarMaxWidth( new Rect( editableElement ).width );
 				}
 			}
 		} );
@@ -181,5 +184,17 @@ export default class InlineEditorUI extends EditorUI {
 				isDirectHost: false
 			} );
 		}
+	}
+
+	/**
+	 * Set max-width for toolbar.
+	 *
+	 * @private
+	 */
+	_setToolbarMaxWidth( width ) {
+		const view = this.view;
+		const toolbar = view.toolbar;
+
+		toolbar.element.style.maxWidth = `${ width }px`;
 	}
 }

--- a/src/inlineeditorui.js
+++ b/src/inlineeditorui.js
@@ -11,7 +11,7 @@ import EditorUI from '@ckeditor/ckeditor5-core/src/editor/editorui';
 import enableToolbarKeyboardFocus from '@ckeditor/ckeditor5-ui/src/toolbar/enabletoolbarkeyboardfocus';
 import normalizeToolbarConfig from '@ckeditor/ckeditor5-ui/src/toolbar/normalizetoolbarconfig';
 import { enablePlaceholder } from '@ckeditor/ckeditor5-engine/src/view/placeholder';
-import Rect from '@ckeditor/ckeditor5-utils/src/dom/rect';
+import getResizeObserver from '@ckeditor/ckeditor5-utils/src/dom/getresizeobserver';
 
 /**
  * The inline editor UI class.
@@ -144,11 +144,6 @@ export default class InlineEditorUI extends EditorUI {
 					target: editableElement,
 					positions: view.panelPositions
 				} );
-
-				// Set toolbar's max-width only once.
-				if ( toolbar.element.style.maxWidth === '' ) {
-					this._setToolbarMaxWidth( new Rect( editableElement ).width );
-				}
 			}
 		} );
 
@@ -160,6 +155,13 @@ export default class InlineEditorUI extends EditorUI {
 			originKeystrokeHandler: editor.keystrokes,
 			toolbar
 		} );
+
+		// Set toolbar's max-width on the initialization and update it on the editable resize.
+		const widthObserver = getResizeObserver( ( [ entry ] ) => {
+			this._setToolbarMaxWidth( entry.contentRect.width );
+		} );
+
+		widthObserver.observe( editableElement );
 	}
 
 	/**
@@ -195,6 +197,6 @@ export default class InlineEditorUI extends EditorUI {
 		const view = this.view;
 		const toolbar = view.toolbar;
 
-		toolbar.element.style.maxWidth = `${ width }px`;
+		toolbar.maxWidth = width;
 	}
 }

--- a/src/inlineeditorui.js
+++ b/src/inlineeditorui.js
@@ -12,6 +12,9 @@ import enableToolbarKeyboardFocus from '@ckeditor/ckeditor5-ui/src/toolbar/enabl
 import normalizeToolbarConfig from '@ckeditor/ckeditor5-ui/src/toolbar/normalizetoolbarconfig';
 import { enablePlaceholder } from '@ckeditor/ckeditor5-engine/src/view/placeholder';
 import getResizeObserver from '@ckeditor/ckeditor5-utils/src/dom/getresizeobserver';
+import toUnit from '@ckeditor/ckeditor5-utils/src/dom/tounit';
+
+const toPx = toUnit( 'px' );
 
 /**
  * The inline editor UI class.
@@ -197,6 +200,6 @@ export default class InlineEditorUI extends EditorUI {
 		const view = this.view;
 		const toolbar = view.toolbar;
 
-		toolbar.maxWidth = width;
+		toolbar.maxWidth = toPx( width );
 	}
 }

--- a/src/inlineeditorui.js
+++ b/src/inlineeditorui.js
@@ -11,11 +11,6 @@ import EditorUI from '@ckeditor/ckeditor5-core/src/editor/editorui';
 import enableToolbarKeyboardFocus from '@ckeditor/ckeditor5-ui/src/toolbar/enabletoolbarkeyboardfocus';
 import normalizeToolbarConfig from '@ckeditor/ckeditor5-ui/src/toolbar/normalizetoolbarconfig';
 import { enablePlaceholder } from '@ckeditor/ckeditor5-engine/src/view/placeholder';
-import Rect from '@ckeditor/ckeditor5-utils/src/dom/rect';
-import getResizeObserver from '@ckeditor/ckeditor5-utils/src/dom/getresizeobserver';
-import toUnit from '@ckeditor/ckeditor5-utils/src/dom/tounit';
-
-const toPx = toUnit( 'px' );
 
 /**
  * The inline editor UI class.
@@ -155,23 +150,6 @@ export default class InlineEditorUI extends EditorUI {
 			originKeystrokeHandler: editor.keystrokes,
 			toolbar
 		} );
-
-		// Set the toolbar's max-width on the initialization and update it on the editable resize,
-		// if 'shouldToolbarGroupWhenFull' in config is set to 'true'.
-		if ( !this._toolbarConfig.shouldNotGroupWhenFull ) {
-			const widthObserver = getResizeObserver( () => {
-				// We need to check if there's already the editable element in the DOM.
-				// Otherwise the `Rect` instance will complain that source (editableElement) is not available
-				// to obtain the element's geometry.
-				if ( !editableElement.ownerDocument.body.contains( editableElement ) ) {
-					return;
-				}
-
-				this.view.toolbar.maxWidth = toPx( new Rect( editableElement ).width );
-			} );
-
-			widthObserver.observe( editableElement );
-		}
 	}
 
 	/**

--- a/src/inlineeditorui.js
+++ b/src/inlineeditorui.js
@@ -159,12 +159,15 @@ export default class InlineEditorUI extends EditorUI {
 			toolbar
 		} );
 
-		// Set toolbar's max-width on the initialization and update it on the editable resize.
-		const widthObserver = getResizeObserver( ( [ entry ] ) => {
-			this._setToolbarMaxWidth( entry.contentRect.width );
-		} );
+		// Set toolbar's max-width on the initialization and update it on the editable resize,
+		// if 'shouldToolbarGroupWhenFull' in config is set to 'true'.
+		if ( !this._toolbarConfig.shouldNotGroupWhenFull ) {
+			const widthObserver = getResizeObserver( ( [ entry ] ) => {
+				this._setToolbarMaxWidth( entry.contentRect.width );
+			} );
 
-		widthObserver.observe( editableElement );
+			widthObserver.observe( editableElement );
+		}
 	}
 
 	/**

--- a/src/inlineeditoruiview.js
+++ b/src/inlineeditoruiview.js
@@ -31,6 +31,9 @@ export default class InlineEditorUIView extends EditorUIView {
 	 * @param {HTMLElement} [editableElement] The editable element. If not specified, it will be automatically created by
 	 * {@link module:ui/editableui/editableuiview~EditableUIView}. Otherwise, the given element will be used.
 	 * @param {Object} [options={}] Configuration options for the view instance.
+	 * @param {Boolean} [options.shouldToolbarGroupWhenFull] When set `true` enables automatic items grouping
+	 * in the main {@link module:editor-inline/inlineeditoruiview~InlineEditorUIView#toolbar toolbar}.
+	 * See {@link module:ui/toolbar/toolbarview~ToolbarOptions#shouldGroupWhenFull} to learn more.
 	 */
 	constructor( locale, editingView, editableElement, options = {} ) {
 		super( locale );
@@ -148,10 +151,10 @@ export default class InlineEditorUIView extends EditorUIView {
 		 *
 		 * **Note:** Created in {@link #render}.
 		 *
-		 * @readonly
-		 * @member {module:utils/dom/getresizeobserver~ResizeObserver}
+		 * @private
+		 * @member {module:utils/dom/resizeobserver~ResizeObserver}
 		 */
-		this.resizeObserver = null;
+		this._resizeObserver = null;
 	}
 
 	/**
@@ -170,14 +173,8 @@ export default class InlineEditorUIView extends EditorUIView {
 		// if 'shouldToolbarGroupWhenFull' in config is set to 'true'.
 		if ( options.shouldGroupWhenFull ) {
 			const editableElement = this.editable.element;
-			this.resizeObserver = new ResizeObserver( editableElement, () => {
-				// We need to check if there's already the editable element in the DOM.
-				// Otherwise the `Rect` instance will complain that source (editableElement) is not available
-				// to obtain the element's geometry.
-				if ( !editableElement.ownerDocument.body.contains( editableElement ) ) {
-					return;
-				}
 
+			this._resizeObserver = new ResizeObserver( editableElement, () => {
 				this.toolbar.maxWidth = toPx( new Rect( editableElement ).width );
 			} );
 		}
@@ -189,8 +186,8 @@ export default class InlineEditorUIView extends EditorUIView {
 	destroy() {
 		super.destroy();
 
-		if ( this.resizeObserver ) {
-			this.resizeObserver.destroy();
+		if ( this._resizeObserver ) {
+			this._resizeObserver.destroy();
 		}
 	}
 

--- a/src/inlineeditoruiview.js
+++ b/src/inlineeditoruiview.js
@@ -12,7 +12,7 @@ import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/i
 import BalloonPanelView from '@ckeditor/ckeditor5-ui/src/panel/balloon/balloonpanelview';
 import ToolbarView from '@ckeditor/ckeditor5-ui/src/toolbar/toolbarview';
 import Rect from '@ckeditor/ckeditor5-utils/src/dom/rect';
-import getResizeObserver from '@ckeditor/ckeditor5-utils/src/dom/getresizeobserver';
+import ResizeObserver from '@ckeditor/ckeditor5-utils/src/dom/resizeobserver';
 import toUnit from '@ckeditor/ckeditor5-utils/src/dom/tounit';
 
 const toPx = toUnit( 'px' );
@@ -141,6 +141,17 @@ export default class InlineEditorUIView extends EditorUIView {
 		 * @member {module:ui/editableui/inline/inlineeditableuiview~InlineEditableUIView}
 		 */
 		this.editable = new InlineEditableUIView( locale, editingView, editableElement );
+
+		/**
+		 * An instance of the resize observer that helps dynamically determine the geometry of the toolbar
+		 * and manage items that do not fit into a single row.
+		 *
+		 * **Note:** Created in {@link #render}.
+		 *
+		 * @readonly
+		 * @member {module:utils/dom/getresizeobserver~ResizeObserver}
+		 */
+		this.resizeObserver = null;
 	}
 
 	/**
@@ -159,7 +170,7 @@ export default class InlineEditorUIView extends EditorUIView {
 		// if 'shouldToolbarGroupWhenFull' in config is set to 'true'.
 		if ( options.shouldGroupWhenFull ) {
 			const editableElement = this.editable.element;
-			const widthObserver = getResizeObserver( () => {
+			this.resizeObserver = new ResizeObserver( editableElement, () => {
 				// We need to check if there's already the editable element in the DOM.
 				// Otherwise the `Rect` instance will complain that source (editableElement) is not available
 				// to obtain the element's geometry.
@@ -169,8 +180,17 @@ export default class InlineEditorUIView extends EditorUIView {
 
 				this.toolbar.maxWidth = toPx( new Rect( editableElement ).width );
 			} );
+		}
+	}
 
-			widthObserver.observe( editableElement );
+	/**
+	 * @inheritDoc
+	 */
+	destroy() {
+		super.destroy();
+
+		if ( this.resizeObserver ) {
+			this.resizeObserver.destroy();
 		}
 	}
 

--- a/src/inlineeditoruiview.js
+++ b/src/inlineeditoruiview.js
@@ -35,7 +35,9 @@ export default class InlineEditorUIView extends EditorUIView {
 		 * @readonly
 		 * @member {module:ui/toolbar/toolbarview~ToolbarView}
 		 */
-		this.toolbar = new ToolbarView( locale, { shouldGroupWhenFull: options.shouldToolbarGroupWhenFull } );
+		this.toolbar = new ToolbarView( locale, {
+			shouldGroupWhenFull: options.shouldToolbarGroupWhenFull
+		} );
 
 		/**
 		 * The offset from the top edge of the web browser's viewport which makes the

--- a/src/inlineeditoruiview.js
+++ b/src/inlineeditoruiview.js
@@ -26,7 +26,7 @@ export default class InlineEditorUIView extends EditorUIView {
 	 * @param {HTMLElement} [editableElement] The editable element. If not specified, it will be automatically created by
 	 * {@link module:ui/editableui/editableuiview~EditableUIView}. Otherwise, the given element will be used.
 	 */
-	constructor( locale, editingView, editableElement ) {
+	constructor( locale, editingView, editableElement, options = {} ) {
 		super( locale );
 
 		/**
@@ -35,7 +35,7 @@ export default class InlineEditorUIView extends EditorUIView {
 		 * @readonly
 		 * @member {module:ui/toolbar/toolbarview~ToolbarView}
 		 */
-		this.toolbar = new ToolbarView( locale, { shouldGroupWhenFull: true } );
+		this.toolbar = new ToolbarView( locale, { shouldGroupWhenFull: options.shouldToolbarGroupWhenFull } );
 
 		/**
 		 * The offset from the top edge of the web browser's viewport which makes the

--- a/src/inlineeditoruiview.js
+++ b/src/inlineeditoruiview.js
@@ -35,7 +35,7 @@ export default class InlineEditorUIView extends EditorUIView {
 		 * @readonly
 		 * @member {module:ui/toolbar/toolbarview~ToolbarView}
 		 */
-		this.toolbar = new ToolbarView( locale );
+		this.toolbar = new ToolbarView( locale, { shouldGroupWhenFull: true } );
 
 		/**
 		 * The offset from the top edge of the web browser's viewport which makes the

--- a/tests/inlineeditor.js
+++ b/tests/inlineeditor.js
@@ -183,8 +183,9 @@ describe( 'InlineEditor', () => {
 			} );
 		} );
 
-		it( 'inline toolbar should not group items when shouldNotGroupWhenFull option is enabled', () => {
+		it( 'should pass the config.toolbar.shouldNotGroupWhenFull configuration to the view', () => {
 			const editorElement = document.createElement( 'div' );
+
 			return InlineEditor.create( editorElement, {
 				toolbar: {
 					shouldNotGroupWhenFull: true

--- a/tests/inlineeditor.js
+++ b/tests/inlineeditor.js
@@ -183,7 +183,7 @@ describe( 'InlineEditor', () => {
 			} );
 		} );
 
-		it( 'inline toolbar should group items by default', () => {
+		it( 'inline toolbar should not group items when shouldNotGroupWhenFull option is enabled', () => {
 			const editorElement = document.createElement( 'div' );
 			return InlineEditor.create( editorElement, {
 				toolbar: {

--- a/tests/inlineeditor.js
+++ b/tests/inlineeditor.js
@@ -183,6 +183,21 @@ describe( 'InlineEditor', () => {
 			} );
 		} );
 
+		it( 'inline toolbar should group items by default', () => {
+			const editorElement = document.createElement( 'div' );
+			return InlineEditor.create( editorElement, {
+				toolbar: {
+					shouldNotGroupWhenFull: true
+				}
+			} ).then( editor => {
+				expect( editor.ui.view.toolbar.options.shouldGroupWhenFull ).to.be.false;
+
+				return editor.destroy();
+			} ).then( () => {
+				editorElement.remove();
+			} );
+		} );
+
 		it( 'throws if initial data is passed in Editor#create and config.initialData is also used', done => {
 			InlineEditor.create( '<p>Hello world!</p>', {
 				initialData: '<p>I am evil!</p>',

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -97,6 +97,8 @@ describe( 'InlineEditorUI', () => {
 					target: view.editable.element,
 					positions: sinon.match.array
 				} );
+
+				viewElement.remove();
 			} );
 
 			it( 'pin() is not called on editor.ui#update when panel is hidden', () => {
@@ -135,6 +137,8 @@ describe( 'InlineEditorUI', () => {
 				editor.ui.fire( 'update' );
 
 				sinon.assert.calledOnce( spy );
+
+				viewElement.remove();
 			} );
 
 			it( 'toolbar should group items by default', () => {

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -127,7 +127,7 @@ describe( 'InlineEditorUI', () => {
 				sinon.assert.notCalled( spy );
 			} );
 
-			it( 'toolbar max-width is set to the value of width of the editable element, otherwise it can be wider then editor', done => {
+			it( 'should set inline toolbar max-width to the width of the editable element', done => {
 				document.body.appendChild( viewElement );
 
 				expect( document.body.contains( viewElement ) ).to.be.true;
@@ -143,10 +143,6 @@ describe( 'InlineEditorUI', () => {
 
 					done();
 				}, 100 );
-			} );
-
-			it( 'toolbar should group items by default', () => {
-				expect( view.toolbar.options.shouldGroupWhenFull ).to.be.true;
 			} );
 		} );
 

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -121,24 +121,19 @@ describe( 'InlineEditorUI', () => {
 				sinon.assert.notCalled( spy );
 			} );
 
-			it( 'toolbar max-width is set on editor.ui#update only once when editable element is in the DOM', () => {
-				const spy = sinon.spy( editor.ui, '_setToolbarMaxWidth' );
-				testUtils.sinon.stub( viewElement, 'getBoundingClientRect' ).returns( { width: 100 } );
+			// TODO: HELP?
+			it( 'toolbar max-width is set to the value of width of the editable element', () => {
+				document.body.appendChild( viewElement );
 
-				viewElement.ownerDocument.body.append( viewElement );
-				view.panel.show();
+				viewElement.style.width = '400px';
 
-				expect( view.toolbar.element.style.maxWidth ).to.be.equal( '' );
+				expect( viewElement.ownerDocument.body.contains( viewElement ) ).to.be.true;
+				expect( view.toolbar.element.ownerDocument.body.contains( view.toolbar.element ) ).to.be.true;
+				expect( view.toolbar.element.style.maxWidth ).to.be.equal( '400px' );
 
-				editor.ui.fire( 'update' );
+				document.body.removeChild( viewElement );
 
-				expect( view.toolbar.element.style.maxWidth ).to.be.equal( '100px' );
-
-				editor.ui.fire( 'update' );
-
-				sinon.assert.calledOnce( spy );
-
-				viewElement.remove();
+				expect( viewElement ).to.not.exist;
 			} );
 
 			it( 'toolbar should group items by default', () => {

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -142,7 +142,7 @@ describe( 'InlineEditorUI', () => {
 					expect( view.toolbar.maxWidth ).to.be.equal( '400px' );
 
 					done();
-				}, 100 );
+				}, 500 );
 			} );
 		} );
 

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -83,15 +83,13 @@ describe( 'InlineEditorUI', () => {
 			} );
 
 			// https://github.com/ckeditor/ckeditor5-editor-inline/issues/4
-			it( 'pin() is called on editor.ui#update', () => {
+			it( 'pin() is called on editor.ui#update when editable element is in the DOM', () => {
 				const spy = sinon.stub( view.panel, 'pin' );
 
-				view.panel.hide();
-
-				editor.ui.fire( 'update' );
-				sinon.assert.notCalled( spy );
-
+				viewElement.ownerDocument.body.append( viewElement );
 				view.panel.show();
+
+				expect( viewElement.ownerDocument.body.contains( viewElement ) ).to.be.true;
 
 				editor.ui.fire( 'update' );
 				sinon.assert.calledOnce( spy );
@@ -99,6 +97,48 @@ describe( 'InlineEditorUI', () => {
 					target: view.editable.element,
 					positions: sinon.match.array
 				} );
+			} );
+
+			it( 'pin() is not called on editor.ui#update when panel is hidden', () => {
+				const spy = sinon.stub( view.panel, 'pin' );
+
+				view.panel.hide();
+
+				editor.ui.fire( 'update' );
+				sinon.assert.notCalled( spy );
+			} );
+
+			it( 'pin() is not called on editor.ui#update when panel is visible but editable element is not in the DOM', () => {
+				const spy = sinon.stub( view.panel, 'pin' );
+
+				view.panel.show();
+
+				expect( !viewElement.ownerDocument.body.contains( viewElement ) ).to.be.true;
+
+				editor.ui.fire( 'update' );
+				sinon.assert.notCalled( spy );
+			} );
+
+			it( 'toolbar max-width is set on editor.ui#update only once when editable element is in the DOM', () => {
+				const spy = sinon.spy( editor.ui, '_setToolbarMaxWidth' );
+				testUtils.sinon.stub( viewElement, 'getBoundingClientRect' ).returns( { width: 100 } );
+
+				viewElement.ownerDocument.body.append( viewElement );
+				view.panel.show();
+
+				expect( view.toolbar.element.style.maxWidth ).to.be.equal( '' );
+
+				editor.ui.fire( 'update' );
+
+				expect( view.toolbar.element.style.maxWidth ).to.be.equal( '100px' );
+
+				editor.ui.fire( 'update' );
+
+				sinon.assert.calledOnce( spy );
+			} );
+
+			it( 'toolbar should group items by default', () => {
+				expect( view.toolbar.options.shouldGroupWhenFull ).to.be.true;
 			} );
 		} );
 

--- a/tests/inlineeditorui.js
+++ b/tests/inlineeditorui.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals document, Event, setTimeout */
+/* globals document, Event */
 
 import View from '@ckeditor/ckeditor5-ui/src/view';
 
@@ -13,14 +13,10 @@ import InlineEditorUIView from '../src/inlineeditoruiview';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 
-import Rect from '@ckeditor/ckeditor5-utils/src/dom/rect';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import { assertBinding } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 import { isElement } from 'lodash-es';
-import toUnit from '@ckeditor/ckeditor5-utils/src/dom/tounit';
-
-const toPx = toUnit( 'px' );
 
 describe( 'InlineEditorUI', () => {
 	let editor, view, ui, viewElement;
@@ -107,27 +103,6 @@ describe( 'InlineEditorUI', () => {
 
 				editor.ui.fire( 'update' );
 				sinon.assert.notCalled( spy );
-			} );
-
-			// Sometimes this test can fail, due to the fact that it have to wait for async ResizeObserver execution.
-			it( 'should set inline toolbar max-width to the width of the editable element', done => {
-				document.body.appendChild( viewElement );
-
-				expect( document.body.contains( viewElement ) ).to.be.true;
-				viewElement.style.width = '400px';
-
-				// Unfortunately we have to wait for async ResizeObserver execution.
-				// ResizeObserver which has been called after changing width of viewElement,
-				// needs 2x requestAnimationFrame or timeout to update a layout.
-				// See more: https://twitter.com/paul_irish/status/912693347315150849/photo/1
-				setTimeout( () => {
-					const editableWidthWithPadding = toPx( new Rect( viewElement ).width );
-					expect( view.toolbar.maxWidth ).to.be.equal( editableWidthWithPadding );
-
-					document.body.removeChild( viewElement );
-
-					done();
-				}, 500 );
 			} );
 		} );
 

--- a/tests/inlineeditoruiview.js
+++ b/tests/inlineeditoruiview.js
@@ -83,6 +83,9 @@ describe( 'InlineEditorUIView', () => {
 
 	describe( 'render()', () => {
 		beforeEach( () => {
+			// We need to set this option explicitly before render phase,
+			// otherwise it is `undefined` and toolbar items grouping will be skipped in tests.
+			view.toolbar.options.shouldGroupWhenFull = true;
 			view.render();
 		} );
 
@@ -102,8 +105,8 @@ describe( 'InlineEditorUIView', () => {
 			// Sometimes this test can fail, due to the fact that it have to wait for async ResizeObserver execution.
 			it( 'max-width should be set to the width of the editable element', done => {
 				const viewElement = view.editable.element;
-				global.document.body.appendChild( viewElement );
 
+				global.document.body.appendChild( viewElement );
 				expect( global.document.body.contains( viewElement ) ).to.be.true;
 
 				viewElement.style.width = '400px';
@@ -114,7 +117,6 @@ describe( 'InlineEditorUIView', () => {
 				// See more: https://twitter.com/paul_irish/status/912693347315150849/photo/1
 				setTimeout( () => {
 					const editableWidthWithPadding = toPx( new Rect( viewElement ).width );
-
 					expect( view.toolbar.maxWidth ).to.be.equal( editableWidthWithPadding );
 
 					global.document.body.removeChild( viewElement );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: The inline editor toolbar should group items when its width exceeds the editable’s width (see ckeditor/ckeditor5#5597).

BREAKING CHANGE: From now on, the inline toolbar groups overflowing items by default. This behaviour can be disabled via the editor config by setting the [`config.toolbar.shouldNotGroupWhenFull: true`](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_editor_editorconfig-EditorConfig.html#member-toolbar) option.

---
Master PR: https://github.com/ckeditor/ckeditor5-ui/pull/536
CI https://github.com/ckeditor/ckeditor5/compare/i/5597?expand=1
